### PR TITLE
Fix typos in metrics names

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -272,8 +272,8 @@ func NewUwsgiCoreStats() []Stat {
 	return []Stat{
 		NewUwsgiCounterStat("Requests", "Number of requests.", prefix, suffix, &label_names),
 		NewUwsgiCounterStat("Static_Requests", "Number of static requests.", prefix, suffix, &label_names),
-		NewUwsgiCounterStat("Routed_Requets", "Number of routed requests.", prefix, suffix, &label_names),
-		NewUwsgiCounterStat("Ofloaded_Requests", "Number of requests offloaded to threads.", prefix, suffix, &label_names),
+		NewUwsgiCounterStat("Routed_Requests", "Number of routed requests.", prefix, suffix, &label_names),
+		NewUwsgiCounterStat("Offloaded_Requests", "Number of requests offloaded to threads.", prefix, suffix, &label_names),
 		NewUwsgiCounterStat("Write_Errors", "Number of write errors.", prefix, suffix, &label_names),
 		NewUwsgiCounterStat("Read_Errors", "Number of read errors.", prefix, suffix, &label_names),
 		NewUwsgiCounterStat("In_Requests", "Number of requests in.", prefix, suffix, &label_names),

--- a/uwsgi_stats.go
+++ b/uwsgi_stats.go
@@ -73,15 +73,15 @@ type UwsgiApp struct {
 }
 
 type UwsgiCore struct {
-	Id                int
-	Requests          int
-	Static_Requests   int
-	Routed_Requets    int
-	Ofloaded_Requests int
-	Write_Errors      int
-	Read_Errors       int
-	In_Requests       int
-	Vars              []string
+	Id                 int
+	Requests           int
+	Static_Requests    int
+	Routed_Requests    int
+	Offloaded_Requests int
+	Write_Errors       int
+	Read_Errors        int
+	In_Requests        int
+	Vars               []string
 }
 
 type UwsgiUnixGlobAddr string


### PR DESCRIPTION
The changes are naive and they'll probably break current dashboard still for new users it would be nice to have proper names.