### PR TITLE
Report http.ListenAndServe() errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,5 +54,5 @@ func main() {
 	prometheus.MustRegister(collector)
 
 	http.Handle("/metrics", prometheus.Handler())
-	http.ListenAndServe(*addr, nil)
+	fmt.Printf("%s\n", http.ListenAndServe(*addr, nil))
 }


### PR DESCRIPTION
Commit adds reporting of http.ListenAndServe() errors to ease debugging eg.
when given address is already in use.